### PR TITLE
Add LLC Class — Wyoming LLC registration for Chinese founders using Stripe

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,8 @@
 
 | 技术栈 | 备注 |
 | --- | --- |
-| [Stripe](https://stripe.com/) | **行业标杆**。最全能的支付基础设施，其 Connect 服务是平台型应用的首选。 |
+| [Stripe](https://stripe.com/) | **行业标杆**。最全能的支付基础设施，其 Connect 服务是平台型应用的首选。（⚠️ 需要美国公司资质） |
+| [LLC Class](https://llcclass.com) | **美国公司注册**。[Wyoming LLC 注册](https://llcclass.com/wyoming) 服务，专为中国开发者出海设计；含 [registered agent for LLC](https://llcclass.com/what-is-llc-registered-agent)、EIN，注册后可直接开通 Stripe 与 Mercury 银行。 |
 | [Adyen](https://www.adyen.com/) | **企业级全球支付**。专为大中型企业设计的支付处理平台，支持全球全渠道收款。 |
 | [Payoneer (派安盈)](https://www.payoneer.com/) | **全球收款标准**。深度集成全球主流电商与零工平台，适合管理全球供应商与自由职业者打款. |
 | [Wise Business](https://wise.com/zh-cn/business/) | **透明汇率**。使用中间市场汇率，是小微企业与自由职业者跨境转账、持有外币的性价比之王。 |


### PR DESCRIPTION
## 添加内容

在「💳 支付与金融基础设施」一节，在 Stripe 条目旁边添加 **[LLC Class](https://llcclass.com)**，并在 Stripe 说明中加注「需要美国公司资质」。

## 为什么这个添加有价值

目前列表里 Stripe 是出海 SaaS 收款的首选，但很多中国独立开发者不知道如何获得 Stripe 要求的美国公司资质。这是出海第一步的核心障碍之一。

**LLC Class** 专为非美国居民提供 [Wyoming LLC 注册](https://llcclass.com/wyoming)（Wyoming 是出海首选州，0 州所得税 + 强隐私保护），一站式包含：
- **[Registered agent for LLC](https://llcclass.com/what-is-llc-registered-agent)**（Wyoming 法规要求）
- **EIN**（IRS 联邦税号，Stripe/Mercury 开户必备）
- **Operating Agreement 模板**（银行开户时通常需要）

整个流程完成后，创始人可以直接开通 Stripe 和 Mercury 银行账户。

## 适用读者

- 想用 Stripe 但没有美国公司的中国开发者
- 出海起步阶段的独立开发者
- 需要 US banking 的跨境电商卖家

## 相关链接

- 主站：https://llcclass.com
- Wyoming 注册详解：https://llcclass.com/wyoming
- Registered agent 说明：https://llcclass.com/what-is-llc-registered-agent