### PR TITLE
添加 Seedream AI Studio 到 AI 创意与媒体流分类

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@
 | --- | --- |
 | **Runway Gen-3 / Luma Dream Machine** | 视频生成领域的领跑者，支持极高质量的物理引擎模拟。 |
 | **Midjourney V6 / Flux.1** | 2026 年图像生成的金标准，Flux 在文字渲染与真实感上更胜一筹。 |
+| **[Seedream AI Studio](https://seedream4.video/)** | **字节跳动多模型图像生成**。Seedream 5.0/4.5/4.0 模型集成，AI 图像竞技场排名第一，支持最多 10 张参考图，免费可用。 |
 | **HeyGen** | **数字人视频**。目前最强的 AI 数字人生成、视频翻译与口型同步平台。 |
 | **ElevenLabs** | 依然是语音合成（TTS）的霸主，多语言表现无懈可击。 |
 


### PR DESCRIPTION
在「AI 创意与媒体流 (Creative AI)」分类下添加 Seedream AI Studio（https://seedream4.video/）。

**理由：**
- Seedream AI Studio 是字节跳动推出的多模型 AI 图像生成平台，集成 Seedream 5.0/4.5/4.0 模型
- 在 AI 图像竞技场（AI Image Arena）中排名**第一**，是当前最强的图像生成平台之一
- 支持最多 10 张参考图组合生成，一键调用 Kling 2.1 视频生成
- 提供免费版，对独立开发者友好

与列表中 Midjourney V6 / Flux.1 并列，是国内开发者出海必知的 ByteDance 顶级图像 AI 工具。