### PR TITLE
添加 NotFair：开源 Claude Code AI 营销技能集（SEO + Google Ads + Meta Ads）

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@
 | [Pinterest Ads](https://ads.pinterest.com/) | **高客单价蓝海**。适合家居、时尚、艺术类商品，用户购买意向高且视觉属性强。 |
 | [HypeAuditor / Modash](https://hypeauditor.com/) | **KOL/KOC 撮合与审计**。通过海量数据分析达人真实影响力，避免刷量坑。 |
 | [Grin / Upfluence](https://grin.co/) | **达人管理平台**。一站式处理全球博主联系、寄样、合同与佣金结算的 SaaS 系统。 |
+| [NotFair](https://github.com/nowork-studio/NotFair) | **开源 AI 营销技能集**。Claude Code 插件，涵盖 SEO（关键词研究、结构化数据、GEO 优化）、Google Ads 和 Meta Ads 技能，通过 Google Ads MCP、Meta Ads MCP、Google Search Console MCP 和 Google Analytics (GA4) MCP 连接实时数据，约 2.9k stars，MIT 开源。 |
 
 ### 能力开放平台 (Capability & API Platforms)
 


### PR DESCRIPTION
感谢您维护这份出色的独立开发者工具清单！

想推荐一个开源项目 **[NotFair](https://github.com/nowork-studio/NotFair)**，将其加入「全球营销、广告与达人撮合」分类。

NotFair 是一套 Claude Code 技能插件（MIT 开源，约 2.9k stars），专为营销场景设计，覆盖三大方向：

- **SEO**：关键词研究、meta 标签优化、JSON-LD 结构化数据生成、GEO 优化、内容写作
- **Google Ads**：账户审计、浪费消耗检测、搜索词清理、关键词与出价管理
- **Meta Ads**：ROAS 分析、创意疲劳检测、受众重叠诊断

它通过 Google Ads MCP、Meta Ads MCP、Google Search Console MCP 和 Google Analytics (GA4) MCP 连接实时数据，让 Claude 直接读取和操作广告账户。

如果描述或分类位置需要调整，请随时告知，很乐意配合修改。