### PR TITLE
新增 AgentCeres 到全球营销、广告与达人撮合

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@
 | [Pinterest Ads](https://ads.pinterest.com/) | **高客单价蓝海**。适合家居、时尚、艺术类商品，用户购买意向高且视觉属性强。 |
 | [HypeAuditor / Modash](https://hypeauditor.com/) | **KOL/KOC 撮合与审计**。通过海量数据分析达人真实影响力，避免刷量坑。 |
 | [Grin / Upfluence](https://grin.co/) | **达人管理平台**。一站式处理全球博主联系、寄样、合同与佣金结算的 SaaS 系统。 |
+| [AgentCeres](https://agentceres.com) | **AI 增长团队**。面向独立开发者和小团队，营销 Agent 分工做竞品调研、SEO 与社媒内容草稿，发布前人工审批，14 天免费试用。 |
 
 ### 能力开放平台 (Capability & API Platforms)
 


### PR DESCRIPTION
在「全球营销、广告与达人撮合」分类下新增 AgentCeres（https://agentceres.com）。

这是一款面向独立开发者和小型 SaaS/App 团队的 AI 增长团队产品：营销 Agent 分工负责竞品调研、SEO 内容草稿、社媒帖子草稿及广告增长计划，所有对外发布均需人工审批。提供 14 天免费试用，无需信用卡。

单行改动，未改动其他内容。