### PR TITLE
fix: update job example for current browser-use

### DIFF
--- a/docs/projects/automated-job-application-bot/README.md
+++ b/docs/projects/automated-job-application-bot/README.md
@@ -11,7 +11,7 @@
 
 ## 环境准备
 1. **基础环境**
-   - Python 3.9+（推荐 3.10，避免依赖兼容性问题）
+   - Python 3.11+（推荐 3.11）
    - 谷歌浏览器（Chrome 110+，需与 `browser-use` 支持的版本匹配）
    - Azure OpenAI 账号（获取 API 密钥与端点，用于 AI 岗位分析）
 
@@ -39,7 +39,7 @@ source venv/bin/activate
 ### 2. 安装依赖
 通过 `pip` 安装所有必需包：
 ```bash
-pip install python-dotenv PyPDF2 langchain-openai browser-use
+pip install python-dotenv PyPDF2 browser-use
 ```
 
 ### 3. 配置环境变量
@@ -53,7 +53,7 @@ AZURE_OPENAI_ENDPOINT=你的Azure OpenAI端点（如：https://xxx.openai.azure.
 ### 4. 运行工具
 ```bash
 # 执行主脚本
-python job_finder.py
+python automated_job_application_bot.py
 ```
 运行后将自动：
 1. 加载简历内容
@@ -64,7 +64,7 @@ python job_finder.py
 
 ## 核心配置说明
 ### 1. 调整搜索目标
-修改 `job_finder.py` 中 `main()` 函数的 `companies` 列表，添加/删除需要搜索的公司：
+修改 `automated_job_application_bot.py` 中 `main()` 函数的 `companies` 列表，添加/删除需要搜索的公司：
 ```python
 # 示例：搜索 Google、Microsoft、NVIDIA 的实习
 companies = [
@@ -87,14 +87,12 @@ base_task = (
 ```
 
 ### 3. 浏览器路径配置
-若 Chrome 安装路径与默认不同（如 Windows 系统），修改 `BrowserConfig` 中的 `browser_binary_path`：
+若 Chrome 安装路径与默认不同（如 Windows 系统），修改 `BrowserSession` 中的 `executable_path`：
 ```python
 # Windows 示例路径（需根据实际安装位置调整）
-browser = Browser(
-    config=BrowserConfig(
-        browser_binary_path='C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
-        disable_security=True,
-    )
+browser = BrowserSession(
+    executable_path='C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+    disable_security=True,
 )
 ```
 
@@ -116,11 +114,11 @@ browser = Browser(
    - 检查 Azure 账号是否有权限访问 GPT-4o 模型，且 API 密钥未过期
 
 3. **浏览器无法启动**  
-   - 确认 Chrome 版本 ≥ 110，且 `browser_binary_path` 指向正确的 Chrome 可执行文件
+   - 确认 Chrome 版本 ≥ 110，且 `executable_path` 指向正确的 Chrome 可执行文件
    - 若提示“安全设置阻止”，尝试关闭 Chrome 所有进程后重新运行
 
 
 ## 注意事项
 - 遵守目标公司招聘页面的 `robots.txt` 规则，避免频繁请求导致 IP 被限制
-- 简历内容仅本地读取，不会上传至第三方服务器，确保数据安全
-- 若需自动申请职位，可扩展 `upload_cv` 函数（现有代码已包含简历上传能力，需结合具体招聘页表单调整）
+- 简历文本会发送给 Azure OpenAI 用于匹配；只有在页面需要时，Browser Use 才会上传简历文件
+- 现有代码通过 `available_file_paths` 将简历提供给 Browser Use，需上传时由内置操作处理

--- a/docs/projects/automated-job-application-bot/automated_job_application_bot.py
+++ b/docs/projects/automated-job-application-bot/automated_job_application_bot.py
@@ -1,18 +1,12 @@
+import asyncio
 import csv
 import os
-import asyncio
 from pathlib import Path
-from typing import Optional
 
+from browser_use import Agent, BrowserSession, ChatAzureOpenAI, Controller
 from dotenv import load_dotenv
+from pydantic import BaseModel
 from PyPDF2 import PdfReader
-from langchain_openai import AzureChatOpenAI
-from pydantic import BaseModel, SecretStr
-
-# 导入浏览器控制相关模块
-from browser_use import Agent, Controller
-from browser_use.browser.context import BrowserContext
-from browser_use.browser.browser import Browser, BrowserConfig
 
 # 加载环境变量
 load_dotenv()
@@ -33,8 +27,8 @@ class Job(BaseModel):
     title: str
     link: str
     company: str
-    location: Optional[str] = None
-    salary: Optional[str] = None
+    location: str | None = None
+    salary: str | None = None
 
 # 控制器初始化
 controller = Controller()
@@ -65,45 +59,21 @@ def read_cv():
                 text += page_text
         
         return f"简历内容: {text[:500]}..."  # 只返回前500字符避免过长
-    except Exception as e:
-        return f"读取简历出错: {str(e)}"
-
-# 上传简历
-@controller.action('上传简历到指定位置')
-async def upload_cv(index: int, browser: BrowserContext):
-    try:
-        # 获取DOM元素并上传文件
-        dom_el = await browser.get_dom_element_by_index(index)
-        if not dom_el:
-            return f"未找到索引为 {index} 的元素"
-            
-        upload_el = dom_el.get_file_upload_element()
-        if not upload_el:
-            return f"索引为 {index} 的元素不是文件上传控件"
-            
-        # 执行上传操作
-        element = await browser.get_locate_element(upload_el)
-        await element.set_input_files(str(CV_PATH.absolute()))
-        return f"成功上传简历到索引为 {index} 的位置"
-        
-    except Exception as e:
-        return f"上传简历失败: {str(e)}"
+    except Exception as e:  # noqa: BLE001
+        return f"读取简历出错: {e!s}"
 
 # 浏览器配置
-browser = Browser(
-    config=BrowserConfig(
-        browser_binary_path='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-        disable_security=True,
-    )
+browser = BrowserSession(
+    executable_path='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    disable_security=True,
 )
 
 async def main():
     # 配置AI模型
-    ai_model = AzureChatOpenAI(
+    ai_model = ChatAzureOpenAI(
         model='gpt-4o',
-        api_version='2026-10-21',
         azure_endpoint=os.getenv('AZURE_OPENAI_ENDPOINT', ''),
-        api_key=SecretStr(os.getenv('AZURE_OPENAI_KEY', ''))
+        api_key=os.getenv('AZURE_OPENAI_KEY', '')
     )
     
     # 定义搜索任务
@@ -127,11 +97,20 @@ async def main():
     agents = []
     for company in companies:
         task = f"{base_task}\n当前需要搜索的公司：{company}"
-        agent = Agent(task=task, llm=ai_model, controller=controller, browser=browser)
+        agent = Agent(
+            task=task,
+            llm=ai_model,
+            controller=controller,
+            browser_session=browser,
+            available_file_paths=[str(CV_PATH.absolute())],
+        )
         agents.append(agent.run())
     
     # 等待所有任务完成
-    await asyncio.gather(*agents)
+    try:
+        await asyncio.gather(*agents)
+    finally:
+        await browser.stop()
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
The job-application tutorial installs unpinned browser-use, but the sample imports removed browser_use.browser.context and browser_use.browser.browser modules. A fresh documented Python 3.11 install resolves browser-use 0.13.10 and fails at the old import.

Update the sample to BrowserSession, the Browser Use ChatAzureOpenAI adapter, and the built-in file upload action. Always stop the browser session. The matching README must also change: its Python floor, install dependencies, script filename, BrowserSession option, upload instructions, and privacy claim otherwise contradict the sample. Resume text can reach Azure OpenAI; the old claim that it never leaves the machine was inaccurate.

Validation on current main de6011d:
- Fresh Python 3.11 environment using the exact documented pip install command: browser-use 0.13.10.
- Old module import fails; updated module imports with a temporary blank PDF.
- Real Agent and ChatAzureOpenAI construction, built-in upload registration, and resume allowlist pass.
- The configured BrowserSession, run headlessly with a temporary profile, opens https://example.com/ and returns Example Domain.
- pip check, Ruff, compileall, and git diff --check pass.

Only the sample and its README changed (+35/-58). No Azure request or live job-board action was run.